### PR TITLE
readme python3 vs python info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Python game version of the dance arcade game, using arrow keys to match the steps of the dance.
 
+Note: When writing the statements below, you may need to change all the statements below with `python3` to `python` depending on your python installation. 
+
 ## To play:
 `python3 -m pydancer play`
 


### PR DESCRIPTION
The reason I'm making this change is that when running on my Windows machine, it only works when I put `python` instead of `python3`